### PR TITLE
Potential fix for code scanning alert no. 4: Shell command built from environment values

### DIFF
--- a/scripts/setup-database.js
+++ b/scripts/setup-database.js
@@ -5,7 +5,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 const DATABASE_NAME = 'couple-connect-db';
 
@@ -40,13 +40,13 @@ async function setupDatabase() {
     // 3. Execute schema
     console.log('🏗️ Creating database schema...');
     const schemaPath = path.join(process.cwd(), 'database', 'schema.sql');
-    execSync(`wrangler d1 execute ${DATABASE_NAME} --file=${schemaPath}`, { stdio: 'inherit' });
+    execFileSync('wrangler', ['d1', 'execute', DATABASE_NAME, `--file=${schemaPath}`], { stdio: 'inherit' });
     console.log('✅ Schema created\n');
 
     // 4. Execute seed data
     console.log('🌱 Inserting seed data...');
     const seedPath = path.join(process.cwd(), 'database', 'seed.sql');
-    execSync(`wrangler d1 execute ${DATABASE_NAME} --file=${seedPath}`, { stdio: 'inherit' });
+    execFileSync('wrangler', ['d1', 'execute', DATABASE_NAME, `--file=${seedPath}`], { stdio: 'inherit' });
     console.log('✅ Seed data inserted\n');
 
     console.log('🎉 Database setup complete!');


### PR DESCRIPTION
Potential fix for [https://github.com/and3rn3t/couple-connect/security/code-scanning/4](https://github.com/and3rn3t/couple-connect/security/code-scanning/4)

To fix the problem, we should avoid constructing a shell command string that includes environment-derived values and passing it to the shell. Instead, we should use the `execFileSync` function from the `child_process` module, which allows us to pass command arguments as an array, ensuring that they are not interpreted by the shell. Specifically, we should replace the use of `execSync` with a string command on line 49 with `execFileSync`, passing the command and its arguments as separate parameters. We should also do the same for line 43, which has the same pattern. This change requires importing `execFileSync` from `child_process` and updating the relevant lines to use it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
