### PR TITLE
Potential fix for code scanning alert no. 5: Shell command built from environment values

### DIFF
--- a/scripts/archive/complete-setup.js
+++ b/scripts/archive/complete-setup.js
@@ -14,7 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 const DATABASE_NAME = 'couple-connect-db';
 const WRANGLER_CONFIG_PATH = path.join(process.cwd(), 'wrangler.toml');
@@ -132,7 +132,7 @@ async function applySchema() {
   logStep('Applying database schema...');
 
   try {
-    execSync(`wrangler d1 execute ${DATABASE_NAME} --file=${SCHEMA_PATH}`, {
+    execFileSync('wrangler', ['d1', 'execute', DATABASE_NAME, `--file=${SCHEMA_PATH}`], {
       stdio: 'inherit',
     });
     logSuccess('Database schema applied');


### PR DESCRIPTION
Potential fix for [https://github.com/and3rn3t/couple-connect/security/code-scanning/5](https://github.com/and3rn3t/couple-connect/security/code-scanning/5)

To fix the problem, we should avoid constructing the shell command as a single string and passing it to `execSync`, which invokes a shell and interprets the string. Instead, we should use `execFileSync` from the `child_process` module, which allows us to pass the command and its arguments as an array, ensuring that file paths and other arguments are not interpreted by the shell. This change should be made in the `applySchema` function, specifically replacing the use of `execSync` with `execFileSync`, and passing the command and arguments as separate parameters. We need to import `execFileSync` if it is not already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
