### PR TITLE
Potential fix for code scanning alert no. 6: Shell command built from environment values

### DIFF
--- a/scripts/archive/complete-setup.js
+++ b/scripts/archive/complete-setup.js
@@ -14,7 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 const DATABASE_NAME = 'couple-connect-db';
 const WRANGLER_CONFIG_PATH = path.join(process.cwd(), 'wrangler.toml');
@@ -132,7 +132,7 @@ async function applySchema() {
   logStep('Applying database schema...');
 
   try {
-    execSync(`wrangler d1 execute ${DATABASE_NAME} --file=${SCHEMA_PATH}`, {
+    execFileSync('wrangler', ['d1', 'execute', DATABASE_NAME, `--file=${SCHEMA_PATH}`], {
       stdio: 'inherit',
     });
     logSuccess('Database schema applied');
@@ -150,7 +150,7 @@ async function insertSeedData() {
   logStep('Inserting seed data...');
 
   try {
-    execSync(`wrangler d1 execute ${DATABASE_NAME} --file=${SEED_PATH}`, {
+    execFileSync('wrangler', ['d1', 'execute', DATABASE_NAME, `--file=${SEED_PATH}`], {
       stdio: 'inherit',
     });
     logSuccess('Seed data inserted');


### PR DESCRIPTION
Potential fix for [https://github.com/and3rn3t/couple-connect/security/code-scanning/6](https://github.com/and3rn3t/couple-connect/security/code-scanning/6)

To fix the problem, we should avoid constructing a shell command string that includes environment-derived values. Instead, we should use `execFileSync` (or `execFile` for async) from the `child_process` module, which allows us to pass the command and its arguments as separate parameters, thus avoiding shell interpretation of special characters in file paths. Specifically, in `insertSeedData`, replace the use of `execSync` with a call to `execFileSync`, passing `"wrangler"` as the command and the arguments as an array: `["d1", "execute", DATABASE_NAME, `--file=${SEED_PATH}`]`. This change should be made in the `insertSeedData` function, and a similar change should be made in the `applySchema` function for consistency and security.

No new imports are needed, as `execFileSync` is already available from `child_process`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
